### PR TITLE
Fix faking with a string and a time zone

### DIFF
--- a/Classes/NSDate+SRGFekable.m
+++ b/Classes/NSDate+SRGFekable.m
@@ -124,19 +124,22 @@ static BOOL doFreeze = NO;
     return [self p_swizzledDateWithTimeIntervalSinceNow:secs];
 }
 
-- (id) p_swizzledInit {
+- (id)init_swizzled {
     if( [NSDate doFaking] ){
-        return [[NSDate alloc]  p_swizzledInitWithTimeIntervalSinceNow:-fakeDiff];
+        NSDate *faked = [[self class] p_reloadFakedNow];
+        self = [self initWithTimeIntervalSinceReferenceDate:faked.timeIntervalSinceReferenceDate];
+        return self;
     }
-    return [self p_swizzledInit];
+    return [self init_swizzled];
 }
 
-- (id) p_swizzledInitWithTimeIntervalSinceNow:(NSTimeInterval)secs {
-    NSDate *faked = [[self class] p_reloadFakedNow];
-    if( faked ){
-        return [self p_swizzledInitWithTimeIntervalSinceNow:secs - fakeDiff];
+- (id) initWithTimeIntervalSinceNow_swizzled:(NSTimeInterval)secs {
+    if( [NSDate doFaking] ){
+        NSDate *faked = [[self class] p_reloadFakedNow];
+        self = [self initWithTimeIntervalSinceReferenceDate:faked.timeIntervalSinceReferenceDate+secs];
+        return self;
     }
-    return [self p_swizzledInitWithTimeIntervalSinceNow:secs];
+    return [self initWithTimeIntervalSinceNow_swizzled:secs];
 }
 
 - (NSTimeInterval) p_swizzledTimeIntervalSinceNow {
@@ -166,11 +169,11 @@ static BOOL doFreeze = NO;
                                            new:@selector(p_swizzledTimeIntervalSinceNow)
         ];
         [self p_swizzleInstanceMethodWithOriginal:@selector(init)
-                                           new:@selector(p_swizzledInit)
+                                           new:@selector(init_swizzled)
          originalClass:NSClassFromString(@"__NSPlaceholderDate")
         ];
         [self p_swizzleInstanceMethodWithOriginal:@selector(initWithTimeIntervalSinceNow:)
-                                              new:@selector(p_swizzledInitWithTimeIntervalSinceNow:)
+                                              new:@selector(initWithTimeIntervalSinceNow_swizzled:)
          originalClass:NSClassFromString(@"__NSPlaceholderDate")
         ];
     }

--- a/Classes/NSDate+SRGFekable.m
+++ b/Classes/NSDate+SRGFekable.m
@@ -66,8 +66,8 @@ static BOOL doFreeze = NO;
                   timeZone:(NSTimeZone *)timeZone
 {
     return [[self class] fakeWithString:dateString
-                                   timeZone:[NSTimeZone systemTimeZone]
-                                     freeze:YES];
+                               timeZone:timeZone
+                                 freeze:YES];
 }
 
 + (void)fakeWithString:(NSString *)dateString

--- a/NSDate+SRGFekable.xcodeproj/xcshareddata/xcschemes/NSDate+SRGFekable.xcscheme
+++ b/NSDate+SRGFekable.xcodeproj/xcshareddata/xcschemes/NSDate+SRGFekable.xcscheme
@@ -72,7 +72,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CC367D851A55348300B87159"
@@ -90,7 +91,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CC367D851A55348300B87159"

--- a/NSDate+SRGFekableTests/NSDate_SRGFekableTests.m
+++ b/NSDate+SRGFekableTests/NSDate_SRGFekableTests.m
@@ -132,7 +132,17 @@
     
 }
 
-- (void) testFakeWithString{
+- (void) testFakeWithStringAndTimeZone{
+    
+    [NSDate fakeWithString:@"2014/01/05 11:32:00"
+                  timeZone:[NSTimeZone timeZoneWithName:@"Asia/Tokyo"]
+     ];
+    NSTimeInterval intervalSince1970 = [[NSDate date] timeIntervalSince1970];
+    XCTAssertEqual(intervalSince1970, 1388889120 );
+    
+}
+
+- (void) testFakeWithStringTimeZoneAndFreeze{
     
     [NSDate fakeWithString:@"2014/01/05 11:32:00"
                       timeZone:[NSTimeZone timeZoneWithName:@"Asia/Tokyo"]

--- a/NSDate+SRGFekableTests/NSDate_SRGFekableTests.m
+++ b/NSDate+SRGFekableTests/NSDate_SRGFekableTests.m
@@ -30,65 +30,61 @@
     XCTAssertFalse([NSDate doFaking]);
     
     [NSDate fakeWithDate:[NSDate dateWithTimeIntervalSinceNow:100] ];
+    const NSTimeInterval sleepInterval = 1;
+    sleep(sleepInterval);
     NSDate *fakedDate = [NSDate date];
     XCTAssertTrue([NSDate doFaking]);
     
-    XCTAssertEqual((int)[fakedDate timeIntervalSinceDate:realDate],100);
+    XCTAssertEqualWithAccuracy([fakedDate timeIntervalSinceDate:realDate],100,0.01);
     XCTAssertTrue([NSDate doFaking]);
     
     [NSDate stopFaking];
     NSDate *realDate2 = [NSDate date];
     XCTAssertFalse([NSDate doFaking]);
-    XCTAssertEqual((int)[realDate2 timeIntervalSinceDate:realDate],0);
+    XCTAssertEqualWithAccuracy([realDate2 timeIntervalSinceDate:realDate],sleepInterval,0.01);
 }
 
 - (void)testInit{
     NSDate *realDate = [[NSDate alloc] init];
     
-    [NSDate fakeWithDate:[NSDate dateWithTimeIntervalSinceNow:100]
-                      freeze:YES
-     ];
-    NSDate *fakedDate =  [[NSDate alloc] init];
-    
-    XCTAssertEqual((int)[fakedDate timeIntervalSinceDate:realDate],100);
+    [NSDate fakeWithDate:[NSDate dateWithTimeIntervalSinceNow:100] freeze:YES];
+    const NSTimeInterval sleepInterval = 1;
+    sleep(sleepInterval);
+    NSDate *fakedDate = [[NSDate alloc] init];
+    XCTAssertEqualWithAccuracy([fakedDate timeIntervalSinceDate:realDate],100,0.01);
     
     [NSDate stopFaking];
     NSDate *realDate2 = [[NSDate alloc] init];
-    XCTAssertEqual((int)[realDate2 timeIntervalSinceDate:realDate],0);
+    XCTAssertEqualWithAccuracy([realDate2 timeIntervalSinceDate:realDate],sleepInterval,0.01);
 }
 
 - (void)testInitWithTimeIntervalSinceNow{
+    NSDate *realDate = [[NSDate alloc] init];
     
-    NSDate *realDate = [NSDate new];
-    NSDate *realDate60 = [[NSDate alloc] initWithTimeIntervalSinceNow:60];
-    NSTimeInterval realDiff = [realDate60 timeIntervalSinceDate:realDate];
+    [NSDate fakeWithDate:[NSDate dateWithTimeIntervalSinceNow:100] freeze:YES];
+    const NSTimeInterval sleepInterval = 1;
+    sleep(sleepInterval);
+    NSDate *fakedDate = [[NSDate alloc] initWithTimeIntervalSinceNow:100];
+    XCTAssertEqualWithAccuracy([fakedDate timeIntervalSinceDate:realDate],200,0.01);
     
-    [NSDate fakeWithString:@"2014/11/11 11:11:11"];
-    
-    NSDate *fakeDate = [NSDate date];
-    NSDate *fakeDate60 = [[NSDate alloc] initWithTimeIntervalSinceNow:60];
-    NSTimeInterval fakeDiff = [fakeDate60 timeIntervalSinceDate:fakeDate];
-    
-    XCTAssertEqual(
-        (int)realDiff,
-        (int)fakeDiff
-    );
-   
+    [NSDate stopFaking];
+    NSDate *realDate2 = [[NSDate alloc] initWithTimeIntervalSinceNow:150];
+    XCTAssertEqualWithAccuracy([realDate2 timeIntervalSinceDate:realDate],150+sleepInterval,0.01);
 }
 
 - (void)testNow {
     NSDate *realDate = [NSDate now];
     
-    [NSDate fakeWithDate:[NSDate dateWithTimeIntervalSinceNow:100]
-                      freeze:YES
-     ];
+    [NSDate fakeWithDate:[NSDate dateWithTimeIntervalSinceNow:100] freeze:YES];
+    const NSTimeInterval sleepInterval = 1;
+    sleep(sleepInterval);
     NSDate *fakedDate = [NSDate now];
     
     XCTAssertEqual((int)[fakedDate timeIntervalSinceDate:realDate],100);
     
     [NSDate stopFaking];
     NSDate *realDate2 = [NSDate now];
-    XCTAssertEqual((int)[realDate2 timeIntervalSinceDate:realDate],0);
+    XCTAssertEqualWithAccuracy([realDate2 timeIntervalSinceDate:realDate],sleepInterval,0.01);
 }
 
 
@@ -96,17 +92,15 @@
     
     NSDate *realDate = [NSDate dateWithTimeIntervalSinceNow:300];
     
-    [NSDate fakeWithDate:
-        [NSDate dateWithTimeIntervalSinceNow:100]
-                      freeze:YES
-    ];
-    
+    [NSDate fakeWithDate:[NSDate dateWithTimeIntervalSinceNow:100] freeze:YES];
+    const NSTimeInterval sleepInterval = 1;
+    sleep(sleepInterval);
     NSDate *fakedDate = [NSDate dateWithTimeIntervalSinceNow:300];
-    XCTAssertEqual((int)[fakedDate timeIntervalSinceDate:realDate],100);
+    XCTAssertEqualWithAccuracy([fakedDate timeIntervalSinceDate:realDate],100,0.01);
     
     [NSDate stopFaking];
     NSDate *realDate2 = [NSDate dateWithTimeIntervalSinceNow:300];
-    XCTAssertEqual((int)[realDate2 timeIntervalSinceDate:realDate],0);
+    XCTAssertEqualWithAccuracy([realDate2 timeIntervalSinceDate:realDate],sleepInterval,0.01);
     
 }
 


### PR DESCRIPTION
I've fixed a small bug: the system time zone was used instead of the given one.
