### PR TITLE
Change podspec to support up to iOS 5.0

### DIFF
--- a/NSDate+SRGFekable.podspec
+++ b/NSDate+SRGFekable.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = { "Norihiro Sakamoto" => "nori0620@gmail.com" }
   s.source       = { :git => "https://github.com/soragoto/NSDate-SRGFekable.git", :tag => "0.0.2" }
-  s.platform     = :ios, '6.0'
+  s.platform     = :ios, '5.0'
   s.source_files = "Classes", "Classes/**/*.{h,m}"
   s.resources    = ['Classes/SRGFakableViewController.xib']
   s.requires_arc = true


### PR DESCRIPTION
It looks like there are no reasons because this library couldn't work on iOS 5. Since my project need iOS 5 support, I performed this change.
